### PR TITLE
Add optional HttpClientFactory for pinners.

### DIFF
--- a/pkg/infura/infura_test.go
+++ b/pkg/infura/infura_test.go
@@ -92,7 +92,7 @@ func TestPinFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	inf := &Infura{httpClient, apikey, secret}
+	inf := &Infura{httpClient, nil, apikey, secret}
 	o, err := inf.PinFile(tmpfile.Name())
 	if err != nil {
 		t.Fatal(err)
@@ -128,7 +128,7 @@ func TestPinWithReader(t *testing.T) {
 		{"bytes.Buffer", bytes.NewBufferString(helper.RandString(6, "lower"))},
 	}
 
-	inf := &Infura{httpClient, apikey, secret}
+	inf := &Infura{httpClient, nil, apikey, secret}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			file := test.file.(io.Reader)
@@ -149,7 +149,7 @@ func TestPinWithBytes(t *testing.T) {
 	mux.HandleFunc("/", handleResponse)
 	defer server.Close()
 
-	inf := &Infura{httpClient, apikey, secret}
+	inf := &Infura{httpClient, nil, apikey, secret}
 	buf := []byte(helper.RandString(6, "lower"))
 	o, err := inf.PinWithBytes(buf)
 	if err != nil {
@@ -168,7 +168,7 @@ func TestPinHash(t *testing.T) {
 
 	hash := "Qmaisz6NMhDB51cCvNWa1GMS7LU1pAxdF4Ld6Ft9kZEP2a"
 
-	inf := &Infura{httpClient, apikey, secret}
+	inf := &Infura{httpClient, nil, apikey, secret}
 	if ok, err := inf.PinHash(hash); !ok || err != nil {
 		t.Error(err)
 	}
@@ -211,7 +211,7 @@ func TestPinDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected creates multipart file")
 	}
-	inf := &Infura{httpClient, apikey, secret}
+	inf := &Infura{httpClient, nil, apikey, secret}
 	o, err := inf.PinDir(body)
 	if err != nil {
 		t.Fatalf("Unexpected pin directory: %v", err)
@@ -252,7 +252,7 @@ func TestRateLimit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	inf := &Infura{httpClient, apikey, secret}
+	inf := &Infura{httpClient, nil, apikey, secret}
 	o, err := inf.PinFile(tmpfile.Name())
 	if err != nil {
 		t.Error(err)

--- a/pkg/nftstorage/nftstorage.go
+++ b/pkg/nftstorage/nftstorage.go
@@ -19,6 +19,7 @@ const api = "https://api.nft.storage"
 // NFTStorage represents an NFTStorage configuration.
 type NFTStorage struct {
 	*http.Client
+	HttpClientFactory func(client *http.Client) *http.Client
 
 	Apikey string
 }
@@ -93,7 +94,10 @@ func (nft *NFTStorage) pinFile(r io.Reader, boundary string) (string, error) {
 	}
 	req.Header.Add("Content-Type", boundary)
 	req.Header.Add("Authorization", "Bearer "+nft.Apikey)
-	client := httpretry.NewClient(nft.Client)
+	if nft.HttpClientFactory == nil {
+		nft.HttpClientFactory = httpretry.NewClient
+	}
+	client := nft.HttpClientFactory(nft.Client)
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err

--- a/pkg/pinata/pinata.go
+++ b/pkg/pinata/pinata.go
@@ -24,6 +24,7 @@ const (
 // Pinata represents a Pinata configuration.
 type Pinata struct {
 	*http.Client
+	HttpClientFactory func(client *http.Client) *http.Client
 
 	Apikey string
 	Secret string
@@ -128,7 +129,10 @@ func (p *Pinata) pinFile(r io.Reader, boundary string) (string, error) {
 		req.Header.Add("Authorization", "Bearer "+p.Apikey)
 	}
 
-	client := httpretry.NewClient(p.Client)
+	if p.HttpClientFactory == nil {
+		p.HttpClientFactory = httpretry.NewClient
+	}
+	client := p.HttpClientFactory(p.Client)
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -175,7 +179,10 @@ func (p *Pinata) PinHash(hash string) (bool, error) {
 		req.Header.Add("Authorization", "Bearer "+p.Apikey)
 	}
 
-	client := httpretry.NewClient(p.Client)
+	if p.HttpClientFactory == nil {
+		p.HttpClientFactory = httpretry.NewClient
+	}
+	client := p.HttpClientFactory(p.Client)
 	resp, err := client.Do(req)
 	if err != nil {
 		return false, err

--- a/pkg/pinata/pinata_test.go
+++ b/pkg/pinata/pinata_test.go
@@ -94,7 +94,7 @@ func TestPinFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pinata := &Pinata{httpClient, pinataKey, pinataSec}
+	pinata := &Pinata{httpClient, nil, pinataKey, pinataSec}
 	o, err := pinata.PinFile(tmpfile.Name())
 	if err != nil {
 		t.Fatal(err)
@@ -132,7 +132,7 @@ func TestPinWithReader(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			pinata := &Pinata{httpClient, pinataKey, pinataSec}
+			pinata := &Pinata{httpClient, nil, pinataKey, pinataSec}
 			file := test.file.(io.Reader)
 			o, err := pinata.PinWithReader(file)
 			if err != nil {
@@ -152,7 +152,7 @@ func TestPinWithBytes(t *testing.T) {
 	defer server.Close()
 
 	buf := []byte(helper.RandString(6, "lower"))
-	pinata := &Pinata{httpClient, pinataKey, pinataSec}
+	pinata := &Pinata{httpClient, nil, pinataKey, pinataSec}
 	o, err := pinata.PinWithBytes(buf)
 	if err != nil {
 		t.Errorf("Unexpected pin directory: %v", err)
@@ -196,7 +196,7 @@ func TestPinDir(t *testing.T) {
 		t.Fatal("Unexpected write content to file")
 	}
 
-	pinata := &Pinata{httpClient, pinataKey, pinataSec}
+	pinata := &Pinata{httpClient, nil, pinataKey, pinataSec}
 	o, err := pinata.PinDir(dir)
 	if err != nil {
 		t.Fatalf("Unexpected pin directory: %v", err)
@@ -214,7 +214,7 @@ func TestPinHash(t *testing.T) {
 
 	hash := "Qmaisz6NMhDB51cCvNWa1GMS7LU1pAxdF4Ld6Ft9kZEP2a"
 
-	pinata := &Pinata{httpClient, pinataKey, pinataSec}
+	pinata := &Pinata{httpClient, nil, pinataKey, pinataSec}
 	if ok, err := pinata.PinHash(hash); !ok || err != nil {
 		t.Error(err)
 	}

--- a/pkg/web3storage/web3storage.go
+++ b/pkg/web3storage/web3storage.go
@@ -19,6 +19,7 @@ const api = "https://api.web3.storage"
 // Web3Storage represents a Web3Storage configuration.
 type Web3Storage struct {
 	*http.Client
+	HttpClientFactory func(client *http.Client) *http.Client
 
 	Apikey string
 }
@@ -100,7 +101,10 @@ func (web3 *Web3Storage) pinFile(r io.Reader, boundary string) (string, error) {
 	}
 	req.Header.Add("Content-Type", boundary)
 	req.Header.Add("Authorization", "Bearer "+web3.Apikey)
-	client := httpretry.NewClient(web3.Client)
+	if web3.HttpClientFactory == nil {
+		web3.HttpClientFactory = httpretry.NewClient
+	}
+	client := web3.HttpClientFactory(web3.Client)
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Description
<!-- Include a summary of the change made and also list the dependencies that are required if any -->

This PR adds optional `HttpClientFactory` func to IPFS pinners. This change is motivated by `httpretry` package loading the whole io.Reader contents into memory which causes OOM. Default `HttpClientFactory` is `httpretry.NewClient`

Closes #

## Checklist
- [x] I have followed the [contributing guidelines](https://github.com/wabarc/.github/blob/main/CONTRIBUTING.md)
- [x] I have reviewed and understood the [Code of Conduct](https://github.com/wabarc/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have searched and make sure there's no duplicate PRs
